### PR TITLE
HOTFIX: add eager loading

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).includes(:user)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: [issue url
](https://github.com/GeorgeMarcus/golfr_backend/issues/1)
**Changes**

Every time the feed of an user was fetched there where n + 1 queries:
- 1 query to fetch all the scores
- n queries to fetch for each scores the user

By adding `.includes(:user)`  the users will be loaded into memory all at the same time and such we will only have 2 queries:
- 1 for fetching the scores
- 1 for fetching the users 

**Before**

<img width="1021" alt="Screenshot 2022-07-11 at 10 49 57" src="https://user-images.githubusercontent.com/107842745/178216956-7124cbe4-de13-4bdb-9963-8dd8e48628d4.png">

**After**

<img width="1009" alt="Screenshot 2022-07-11 at 10 51 31" src="https://user-images.githubusercontent.com/107842745/178216984-f530361b-cc65-4d31-b183-b6f5977d873b.png">
