### PR TITLE
Feature/limit feed size

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.includes(:user).limit(25).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,11 +29,11 @@ User.create!(
 rng = Random.new
 now = Time.zone.today
 User.all.each do |user|
-  5.times do |i|
+  100.times do |i|
     Score.create!(
       user: user,
       total_score: rng.rand(66..99),
-      played_at: now - 5.days + i.days
+      played_at: now - 100.days + i.days
     )
   end
 end

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -30,10 +30,11 @@ describe Api::ScoresController, type: :request do
     it 'should return the latest 25 scores even if more scores are in present' do
       expected_scores = [@score1.serialize, @score2.serialize, @score3.serialize]
       # generate 50 new entries in the score table
-      (1..50).each { |i|
-        score = create(:score, user: @user1, total_score: rand(54..120), played_at: Date.today - i.day).serialize
+      (1..50).each do |i|
+        score = create(:score, user: @user1, total_score: rand(54..120),
+                               played_at: Time.zone.today - i.day).serialize
         expected_scores.append score
-      }
+      end
 
       # sort the expected scores decreasingly by played_at
       expected_scores = expected_scores.sort_by { |item| item[:played_at] }.reverse!
@@ -57,10 +58,11 @@ describe Api::ScoresController, type: :request do
     it 'should return all scores if less than 25' do
       expected_scores = [@score1.serialize, @score2.serialize, @score3.serialize]
       # generate 50 new entries in the score table
-      (1..10).each { |i|
-        score = create(:score, user: @user1, total_score: rand(54..120), played_at: Date.today - i.day).serialize
+      (1..10).each do |i|
+        score = create(:score, user: @user1, total_score: rand(54..120),
+                               played_at: Time.zone.today - i.day).serialize
         expected_scores.append score
-      }
+      end
 
       # sort the expected scores decreasingly by played_at
       expected_scores = expected_scores.sort_by { |item| item[:played_at] }.reverse!
@@ -80,14 +82,13 @@ describe Api::ScoresController, type: :request do
       expect(scores.size).to eq 13
       expect(scores).to eq expected_scores[0, 13]
     end
-
   end
 
   describe 'POST create' do
     it 'should save and return the new score if valid parameters' do
       score_count = Score.count
 
-      post api_scores_path, params: { score: { total_score: 79, played_at: '2021-06-29' } }
+      post api_scores_path, params: { score: { total_score: 79, played_at: '2021-06-29' }}
 
       expect(response).to have_http_status(:ok)
       expect(Score.count).to eq score_count + 1
@@ -107,7 +108,7 @@ describe Api::ScoresController, type: :request do
     it 'should return a validation error if score is played in the future' do
       score_count = Score.count
 
-      post api_scores_path, params: { score: { total_score: 79, played_at: '2090-06-29' } }
+      post api_scores_path, params: { score: { total_score: 79, played_at: '2090-06-29' }}
 
       expect(response).not_to have_http_status(:ok)
       expect(Score.count).to eq score_count
@@ -116,7 +117,7 @@ describe Api::ScoresController, type: :request do
     it 'should return a validation error if score value is too low' do
       score_count = Score.count
 
-      post api_scores_path, params: { score: { total_score: 10, played_at: '2021-06-29' } }
+      post api_scores_path, params: { score: { total_score: 10, played_at: '2021-06-29' }}
 
       expect(response).not_to have_http_status(:ok)
       expect(Score.count).to eq score_count

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -12,7 +12,7 @@ describe Api::ScoresController, type: :request do
   end
 
   describe 'GET feed' do
-    it 'should return the token if valid username/password' do
+    it 'should return the scores ordered by played at if valid username/password' do
       get api_feed_path
 
       expect(response).to have_http_status(:ok)
@@ -26,13 +26,68 @@ describe Api::ScoresController, type: :request do
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
     end
+
+    it 'should return the latest 25 scores even if more scores are in present' do
+      expected_scores = [@score1.serialize, @score2.serialize, @score3.serialize]
+      # generate 50 new entries in the score table
+      (1..50).each { |i|
+        score = create(:score, user: @user1, total_score: rand(54..120), played_at: Date.today - i.day).serialize
+        expected_scores.append score
+      }
+
+      # sort the expected scores decreasingly by played_at
+      expected_scores = expected_scores.sort_by { |item| item[:played_at] }.reverse!
+
+      # convert the date to string
+      expected_scores = expected_scores.map do |score|
+        score[:played_at] = score[:played_at].strftime('%Y-%m-%d')
+        score
+      end
+
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body, symbolize_names: true)
+      scores = response_hash[:scores]
+
+      expect(scores.size).to eq 25
+      expect(scores).to eq expected_scores[0, 25]
+    end
+
+    it 'should return all scores if less than 25' do
+      expected_scores = [@score1.serialize, @score2.serialize, @score3.serialize]
+      # generate 50 new entries in the score table
+      (1..10).each { |i|
+        score = create(:score, user: @user1, total_score: rand(54..120), played_at: Date.today - i.day).serialize
+        expected_scores.append score
+      }
+
+      # sort the expected scores decreasingly by played_at
+      expected_scores = expected_scores.sort_by { |item| item[:played_at] }.reverse!
+
+      # convert the date to string
+      expected_scores = expected_scores.map do |score|
+        score[:played_at] = score[:played_at].strftime('%Y-%m-%d')
+        score
+      end
+
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body, symbolize_names: true)
+      scores = response_hash[:scores]
+
+      expect(scores.size).to eq 13
+      expect(scores).to eq expected_scores[0, 13]
+    end
+
   end
 
   describe 'POST create' do
     it 'should save and return the new score if valid parameters' do
       score_count = Score.count
 
-      post api_scores_path, params: { score: { total_score: 79, played_at: '2021-06-29' }}
+      post api_scores_path, params: { score: { total_score: 79, played_at: '2021-06-29' } }
 
       expect(response).to have_http_status(:ok)
       expect(Score.count).to eq score_count + 1
@@ -52,7 +107,7 @@ describe Api::ScoresController, type: :request do
     it 'should return a validation error if score is played in the future' do
       score_count = Score.count
 
-      post api_scores_path, params: { score: { total_score: 79, played_at: '2090-06-29' }}
+      post api_scores_path, params: { score: { total_score: 79, played_at: '2090-06-29' } }
 
       expect(response).not_to have_http_status(:ok)
       expect(Score.count).to eq score_count
@@ -61,7 +116,7 @@ describe Api::ScoresController, type: :request do
     it 'should return a validation error if score value is too low' do
       score_count = Score.count
 
-      post api_scores_path, params: { score: { total_score: 10, played_at: '2021-06-29' }}
+      post api_scores_path, params: { score: { total_score: 10, played_at: '2021-06-29' } }
 
       expect(response).not_to have_http_status(:ok)
       expect(Score.count).to eq score_count


### PR DESCRIPTION
Fixes: [issue url
](https://github.com/GeorgeMarcus/golfr_backend/issues/21)

**Changes**

`app/controllers/api/scores_controller.rb`: added limit to query such that only 25 scores entries will be fetched;

`db/seeds.rb`: added 100 dummy scores entries so it is easier to test the new limit functionality;

`spec/controllers/api/scores_controller_spec.rb`: add 2 test for the functionality:
- when we have over 25 entries in the score table
- when we have under 25 entries in the score table


**Before**

<img width="1293" alt="before-response" src="https://user-images.githubusercontent.com/107842745/178483320-ee5683a5-e6ce-4d2e-aba2-3805d78fb5c4.png">

<img width="1326" alt="before-test" src="https://user-images.githubusercontent.com/107842745/178483334-05bf6183-e720-4ae2-a0d3-1fe714480af0.png">


**After**

<img width="1306" alt="Screenshot 2022-07-12 at 14 40 41" src="https://user-images.githubusercontent.com/107842745/178483371-b334e5e6-1444-491c-a371-d27579242652.png">

<img width="1304" alt="Screenshot 2022-07-12 at 14 40 54" src="https://user-images.githubusercontent.com/107842745/178483386-31587377-22f5-478e-a555-067d71b390a5.png">
